### PR TITLE
Edited mappings/sioc.ttl via GitHub

### DIFF
--- a/mappings/sioc.ttl
+++ b/mappings/sioc.ttl
@@ -10,7 +10,7 @@
 
 <http://schema.rdfs.org/all> a owl:Ontology;
     dct:title "Mappings between SIOC and schema.rdfs.org terms"@en;
-    dct:description "This is a set of mappings betweens the terms defined in the SIOC Ontology (http://sioc-project.org) and the ones defined at schema.rdfs.org and SIOC ones."@en;
+    dct:description "This is a set of mappings betweens the terms defined in the SIOC Ontology (http://sioc-project.org) and the ones defined at schema.rdfs.org."@en;
     foaf:page <http://schema.rdfs.org/mappings/sioc>;
     rdfs:seeAlso <http://sioc-project.org/>;
     rdfs:seeAlso <http://schema.rdfs.org/>;
@@ -22,9 +22,10 @@
 ## Classes
 
 schema:BlogPosting owl:sameAs sioct:BlogPost .
-schema:Blogs owl:sameAs sioct:Blog .
-schema:UserComments owl:sameAs sioct:Comment .
-schema:UserTweets rdfs:subClassOf sioct:MicroblogPost .
+schema:Blog owl:sameAs sioct:Blog .
+schema:UserComments owl:sameAs sioct:Comment . ## Checking with Alex and Michael if we should remove (actions, not things)
+schema:UserTweets rdfs:subClassOf sioct:MicroblogPost .  ## Checking with Alex and Michael if we should remove (actions, not things)
+schema:Article rdfs:subClassOf sioc:Item .
 schema:WebPage rdfs:subClassOf sioc:Item .
    
 ## Properties (some are not from SIOC, but used simultaneously with SIOC data)


### PR DESCRIPTION
I made some small changes (changed schema:Blogs to schema:Blog) but I wanted to ask you about removing UserTweets and UserComments as I think they are events or actions rather than things.  They are subtypes of the UserInteraction.

Also I added a schema:Article to sioc:Item mapping.  I was going to use Post but I think ScholarlyArticles aren’t strictly Posts...

The other property articleSection could be a type of sioc:topic or dc:subject as it assigns a category to an item? What do you think?
