### PR TITLE
Add PHP in tools

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -51,8 +51,10 @@
 
 					<h3>JavaScript</h3>
 					<p>
-						Philip J&auml;genstedt has developed <a href="https://gitorious.org/microdatajs/">MicrodataJS</a>, a jQuery plug-in for microdata providing, an API similar to the HTML5 Microdata DOM API as well as the <a href="http://foolip.org/microdatajs/live/">Live Microdata</a> tool that allows you to test your markup in the browser.
+						Philip J&auml;genstedt has developed <a href="https://gitorious.org/microdatajs/">MicrodataJS</a>, a jQuery plug-in for microdata providing an API similar to the HTML5 Microdata DOM API, as well as the <a href="http://foolip.org/microdatajs/live/">Live Microdata</a> tool that allows you to test your markup in the browser.
 					</p>
+                                        <h3>PHP</h3>
+                                        <p>Lin Clark has developed <a href="https://github.com/linclark/MicrodataPHP">MicrodataPHP</a>, a PHP library based on MicrodataJS.</p>
 					<h3>Ruby</h3>
 					<p>
 						Gregg Kellogg has developed the <a href="https://github.com/gkellogg/rdf-microdata">RDF::Microdata gem</a> to parse microdata into RDF using the RDF.rb platform. This functionality is also available as an online-service called <a href="http://rdf.greggkellogg.net/distiller">RDF Distiller</a>.


### PR DESCRIPTION
I recently created MicrodataPHP, based on MicrodataJS, so that could be added to the tools library.
