### PR TITLE
add RDFaCE to publishing tools

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -84,6 +84,7 @@
 					 Form-based tools that allow you to generate HTML snippets, decorated with Schema.org terms in microdata:
 					</p>
 					<ul>
+						<li><a href="http://rdface.aksw.org/">RDFaCE</a></li>
 						<li><a href="http://schema-creator.org/">Schema Creator</a></li>
 						<li>The <a href="http://www.microdatagenerator.com/">Microdata Generator</a></li>
 					</ul>


### PR DESCRIPTION
RDFaCE implements the WYSIWYM (What You See Is What You Mean) concept in order to facilitate the process of semantic content authoring.
The new version of RDFaCE is focused on Schema.org . You can create RDFa or Microdata annotations based on the schemas defined by schema.org
The main features of RDFaCE include:

```
* Providing a flexible form-based approach to annotate the content by using schemas defined by schema.org
* Providing a mechanism to select a subset of schemas defined by schema.org
* Providing colors for schemas
* Automatic content annotation
```

More information at http://rdface.aksw.org
