### PR TITLE
JSON: comments for types, and property URLs

### DIFF
--- a/scrapers/schema_scraper.py
+++ b/scrapers/schema_scraper.py
@@ -89,7 +89,8 @@ def get_type_details(url):
                 'domains': [id],
                 'ranges': re.sub('\s+', ' ', row.cssselect("td.prop-ect")[0].text_content()).strip().split(' or '),
                 'comment': get_inner_html(comment),
-                'comment_plain': comment.text_content()
+                'comment_plain': comment.text_content(),
+                'url': base_url + id
         })
     return type
 


### PR DESCRIPTION
Having noticed that all types in all.json had empty comments, and that properties were missing their URL property,
I pulled these two commits together. In all likelihood, this is a matter of the schema.org site drifting away from the
old version of the scraper.

Diffing the old all.json and the new all.json shows only the expected changes.
