### PR TITLE
Fix for multiline literals generation in TURTLE output

### DIFF
--- a/scrapers/schema2rdf.py
+++ b/scrapers/schema2rdf.py
@@ -1,3 +1,6 @@
+from rdflib import Literal
+
+
 def get_prefixed(id):
     if id == 'Text':
         return 'xsd:string'
@@ -15,8 +18,10 @@ def get_prefixed(id):
         return 'xsd:integer'
     return 'schema:' + id
 
-def turtle_escape(s):
-    return s.replace('"', '\\"').encode('utf-8')
+
+def turtle_literal(string):
+    return Literal(string, lang='en').n3().encode('utf-8')
+
 
 def dump_rdf(types_list, types, properties, date, out):
 
@@ -51,9 +56,9 @@ def dump_rdf(types_list, types, properties, date, out):
         if id not in types: continue        # skip datatypes
         t = types[id]
         print >> out, get_prefixed(id) + ' a rdfs:Class;'
-        print >> out, '    rdfs:label "' + turtle_escape(t['label']) + '"@en;'
-        if t['comment_plain'] != None:
-            print >> out, '    rdfs:comment "' + turtle_escape(t['comment_plain']) + '"@en;'
+        print >> out, '    rdfs:label %s;' % turtle_literal(t['label'])
+        if t['comment_plain'] is not None:
+            print >> out, '    rdfs:comment %s;' % turtle_literal(t['comment_plain'])
         for supertype in t['supertypes']:
             print >> out, '    rdfs:subClassOf ' + get_prefixed(supertype) + ';'
         print >> out, '    rdfs:isDefinedBy <' + t['url'] + '>;'
@@ -64,8 +69,8 @@ def dump_rdf(types_list, types, properties, date, out):
     for id in prop_ids:
         p = properties[id]
         print >> out, get_prefixed(p['id']) + ' a rdf:Property;'
-        print >> out, '    rdfs:label "' + turtle_escape(p['label']) + '"@en;'
-        print >> out, '    rdfs:comment "' + turtle_escape(p['comment_plain']) + '"@en;'
+        print >> out, '    rdfs:label %s;' % turtle_literal(p['label'])
+        print >> out, '    rdfs:comment %s;' % turtle_literal(p['comment_plain'])
         if len(p['domains']) == 1:
             print >> out, '    rdfs:domain ' + get_prefixed(p['domains'][0]) + ';'
         elif len(p['domains']) > 1:


### PR DESCRIPTION
This fix uses RDFlib for proper encoding of literals (it's better to reuse results of someones hard work)

Here's the difference before and after the patch:

``` diff
--- before.ttl  2013-12-05 15:16:00.000000000 +0400
+++ after.ttl   2013-12-05 17:09:07.000000000 +0400
@@ -4026,8 +4026,8 @@
     .
 schema:accessibilityAPI a rdf:Property;
     rdfs:label "Accessibility API"@en;
-    rdfs:comment "Indicates that the resource is compatible with the referenced accessibility API (WebSchemas wiki lists possible values).
-     "@en;
+    rdfs:comment """Indicates that the resource is compatible with the referenced accessibility API (WebSchemas wiki lists possible values).
+     """@en;
     rdfs:domain schema:CreativeWork;
     rdfs:range xsd:string;
     rdfs:isDefinedBy <http://schema.org/CreativeWork>;
@@ -4461,10 +4461,10 @@
     .
 schema:audienceType a rdf:Property;
     rdfs:label "Audience Type"@en;
-    rdfs:comment "The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.)
+    rdfs:comment """The target group associated with a given audience (e.g. veterans, car owners, musicians, etc.)
       domain: Audience
       Range: Text
-    "@en;
+    """@en;
     rdfs:domain schema:Audience;
     rdfs:range xsd:string;
     rdfs:isDefinedBy <http://schema.org/Audience>;
```
