### PR TITLE
Add to Tools.html page: PHPStructuredData library

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -55,6 +55,9 @@
 					</p>
                                         <h3>PHP</h3>
                                         <p>Lin Clark has developed <a href="https://github.com/linclark/MicrodataPHP">MicrodataPHP</a>, a PHP library based on MicrodataJS.</p>
+                                        <p>
+                                            Alexandru Pruteanu has developed <a href="https://github.com/PAlexcom/PHPStructuredData">PHPStructuredData</a>, a set of PHP libraries that use the http://schema.org vocabulary to implement and output, based on the context of the page, Microdata or RDFa Lite 1.1 semantics.
+                                        </p>
 					<h3>Ruby</h3>
 					<p>
 						Gregg Kellogg has developed the <a href="https://github.com/gkellogg/rdf-microdata">RDF::Microdata gem</a> to parse microdata into RDF using the RDF.rb platform. This functionality is also available as an online-service called <a href="http://rdf.greggkellogg.net/distiller">RDF Distiller</a>.


### PR DESCRIPTION
I would like to add to tools list the: PHPStructuredData library.

#### Quick intro
A set of PHP libraries that use the http://schema.org vocabulary to implement and output Microdata or RDFa Lite 1.1 semantics.
This library is also used in the Joomla CMS since version 3.2 (called JMicrodata).
Created during the Google Summer of Code 2013 and 2014.

#### More info
For examples and documentation please visit [https://github.com/PAlexcom/PHPStructuredData](https://github.com/PAlexcom/PHPStructuredData)